### PR TITLE
fix: referred to axios via an absolute path to fix build error

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 import { Options, FullRequest, GitType } from "./types";
-import { AxiosRequestConfig } from "../node_modules/axios";
+import { AxiosRequestConfig } from "axios";
 
 /**
  * Validate a Request object for endpoints that require


### PR DESCRIPTION
I got an error when building my own project using TypeScript 3.1.6:

```
node_modules/circleci-api/dist/types/util.d.ts:2:36 - error TS2307: Cannot find module '../node_modules/axios'.

2 import { AxiosRequestConfig } from "../node_modules/axios";
                                     ~~~~~~~~~~~~~~~~~~~~~~~
```

Just changing how the code refers to axios seems to fix it, though!